### PR TITLE
hotfix for class loading

### DIFF
--- a/wp-php-password-hash.php
+++ b/wp-php-password-hash.php
@@ -57,6 +57,11 @@ function wp_check_password( $password, $hash, $user_id = '' ) {
     return apply_filters( 'check_password', $check, $password, $hash, $user_id );
   }
 
+  //if class doesnt exist, pull it in
+  if(!class_exists("PasswordHash")) {
+    require_once ABSPATH . WPINC . '/class-phpass.php';
+  }
+
   // If the stored hash is longer than an MD5, presume the
   // new style phpass portable hash.
   if ( empty($wp_hasher) ) {


### PR DESCRIPTION
apparently the class password hash isnt yet present when trying to access it, maybe a newer version changed it.
~~~
[23-Oct-2017 08:28:42 UTC] PHP Fatal error:  Uncaught Error: Class 'PasswordHash' not found in /home/my1devcon/public_html/wptest/wp-content/plugins/password-hash-disabled/wp-php-password-hash.php:64
Stack trace:
#0 /home/my1devcon/public_html/wptest/wp-includes/user.php(162): wp_check_password('test', '$P$BzCPKMBr7KO3...', 1)
#1 /home/my1devcon/public_html/wptest/wp-includes/class-wp-hook.php(298): wp_authenticate_username_password(Object(WP_User), 'My1', 'test')
#2 /home/my1devcon/public_html/wptest/wp-includes/plugin.php(203): WP_Hook->apply_filters(NULL, Array)
#3 /home/my1devcon/public_html/wptest/wp-includes/pluggable.php(532): apply_filters('authenticate', NULL, 'My1', 'test')
#4 /home/my1devcon/public_html/wptest/wp-includes/user.php(85): wp_authenticate('My1', 'test')
#5 /home/my1devcon/public_html/wptest/wp-login.php(790): wp_signon(Array, true)
#6 {main}
  thrown in /home/my1devcon/public_html/wptest/wp-content/plugins/password-hash-disabled/wp-php-password-hash.php on line 64
~~~