### PR TITLE
Doesn't verify password before upgrading the password hash

### DIFF
--- a/wp-php-password-hash.php
+++ b/wp-php-password-hash.php
@@ -35,7 +35,7 @@ function wp_check_password( $password, $hash, $user_id = '' ) {
   $info = password_get_info($hash);
   if (!empty($info['algo'])) {
     $check = password_verify($password, $hash);
-    if (password_needs_rehash($hash, PASSWORD_DEFAULT)) {
+    if ($check && password_needs_rehash($hash, PASSWORD_DEFAULT)) {
       $hash = wp_set_password($password, $user_id);
     }
 


### PR DESCRIPTION
When the password hash is being upgraded, anyone can login:

* Try password of "password". Access denied. Password hash upgraded with password of "password".
* Try password of "password". Access granted.