### PR TITLE
V3

### DIFF
--- a/src/PasswordHash.php
+++ b/src/PasswordHash.php
@@ -92,7 +92,7 @@ final class PasswordHash {
 	 *
 	 */
 	public function getHash(string $password) {
-		return password_hash($password, $this->algorithm, $this->algorithm_options);
+		return password_hash($this->preHash($password), $this->algorithm, $this->algorithm_options);
 	}
 
 	/**
@@ -115,8 +115,16 @@ final class PasswordHash {
 	}
 
 	private function checkPasswordNative($password, $hash, $user_id = '') {
-		$check = password_verify($password, $hash);
-		$rehash = password_needs_rehash($hash, $this->algorithm, $this->algorithm_options);
+		// Check preHashed password first
+		$check = password_verify($this->preHash($password), $hash);
+		if( $check === true ) {
+			$rehash = password_needs_rehash($hash, $this->algorithm, $this->algorithm_options);
+		} else {
+			// Fallback password check for previous non pre-hashed password
+			$check = password_verify($password, $hash);
+			$rehash = true;
+		}
+
 		return $this->processPasswordCheck($check, $password, $hash, $user_id, $rehash);
 	}
 

--- a/src/PasswordHash.php
+++ b/src/PasswordHash.php
@@ -147,6 +147,27 @@ final class PasswordHash {
 		return apply_filters( 'check_password', $check, $password, $hash, $user_id );
 	}
 
+	/**
+	 * Pre-hashes the password before hashing it with the chosen algorithm.
+	 *
+	 * This method pre-hashes the password based on certain conditions before using the chosen algorithm to hash it.
+	 * If the algorithm is CRYPT_BLOWFISH, which has a 72-character limit, the password is pre-hashed using HMAC.
+	 * If the calculated entropy of the password is lower than 480, indicating low randomness, it is pre-hashed using HMAC.
+	 * If pre-hashing is not required, the method returns null.
+	 *
+	 * @param string $password The password to pre-hash.
+	 * @return string|null Returns the pre-hashed password.
+	 */
+	private function preHash($password) {
+		// bcrypt 72 char limit
+		if($this->algorithm === CRYPT_BLOWFISH) return $this->hmac_base64($password);
+
+		// Low calculated entropy
+		if($this->calculateEntropy($password) < 480) return $this->hmac_base64($password);
+
+		// Pre-hashing is not required just pepper the password
+		return substr($password . SECURE_AUTH_SALT, 0, 4096);
+	}
 
 	/**
 	* Generates a base64-encoded Hash-based Message Authentication Code (HMAC) using the specified algorithm.

--- a/src/PasswordHash.php
+++ b/src/PasswordHash.php
@@ -147,6 +147,29 @@ final class PasswordHash {
 		return apply_filters( 'check_password', $check, $password, $hash, $user_id );
 	}
 
+
+	/**
+	* Generates a base64-encoded Hash-based Message Authentication Code (HMAC) using the specified algorithm.
+	*
+	* This function calculates the HMAC of the provided password using the specified algorithm (default is SHA-512)
+	* and the WordPress SECURE_AUTH_SALT as the secret key. It then encodes the result using base64 encoding.
+	*
+	* @param string $password The password to generate the HMAC for.
+	* @param string $algo Optional. The hashing algorithm to use. Default is 'sha512'.
+	* @return string|null Returns the base64-encoded HMAC string, or null on failure.
+	*/
+	private function hmac_base64(string $password, string $algo = 'sha512') {
+		// Calculate the HMAC using hash_hmac function
+		$hmac = hash_hmac($algo,  $password, SECURE_AUTH_SALT );
+
+		if ($hmac === false) {
+			return null; // Return null on failure
+		}
+
+		// Encode the HMAC using base64 encoding
+		return base64_encode($hmac);
+	}
+
 	/**
 	* Calculates the entropy of a given password.
 	*

--- a/src/PasswordHash.php
+++ b/src/PasswordHash.php
@@ -146,4 +146,24 @@ final class PasswordHash {
 
 		return apply_filters( 'check_password', $check, $password, $hash, $user_id );
 	}
+
+	/**
+	* Calculates the entropy of a given password.
+	*
+	* This function calculates the entropy of the provided password based on the number of unique characters
+	* and the length of the password. The entropy is computed using the formula: Entropy = log2(N^L),
+	* where N is the number of unique characters and L is the length of the password.
+	*
+	* @param string $password The password for which to calculate the entropy.
+	* @return float The entropy of the password.
+	*/
+	public function calculateEntropy($password) {
+		// Count the number of unique characters in the password
+		$uniqueCharacters = count(array_unique(str_split($password)));
+
+		// Calculate the entropy using the formula: Entropy = log2(N^L)
+		$entropy = log(pow($uniqueCharacters, strlen($password)), 2);
+
+		return $entropy;
+	}
 }


### PR DESCRIPTION
Adds three new methods to PasswordHash
- preHash()
- hmac_base64()
- calculateEntropy()

Updates getHash() and checkPasswordNative()
with pre-hashing support

Pre-hashing the password for bcrypt allows for the password not to be truncated to 72 characters, this allows for the Wordpress current max password length of 4096 characters to retain as much as possible the original passwords entropy.

For non bcrypt algorithms calculateEntropy() is used to check the password, if the password entropy is good pre-hashing is skipped only appending the Wordpress constant SECURE_AUTH_SALT to the password, if the password entropy is low we pre-hash it.
